### PR TITLE
Fix profile path on Windows

### DIFF
--- a/cmd/hrm/main.go
+++ b/cmd/hrm/main.go
@@ -52,7 +52,9 @@ func profileFilePath() (string, error) {
 
 	switch runtime.GOOS {
 	case "windows":
-		profilePaths = []string{`%APPDATA%\Human Resource Machine\profiles.bin`}
+		profilePaths = []string{
+			os.ExpandEnv(`$APPDATA/Human Resource Machine/profiles.bin`),
+		}
 	case "darwin":
 		profilePaths = []string{
 			`~/Library/Application Support/Human Resource Machine/profiles.bin`,


### PR DESCRIPTION
That `%APPDATA%` notation only works in the command-line
and GUI shells (better known by the names cmd.exe and explorer.exe)
and certain specific Win32 APIs; it's not actually supported by
filesystem APIs or anything...

Note: I can't figure out how to test this without PR #1